### PR TITLE
Adds method for aligning audio when source are unaligned

### DIFF
--- a/Sources/VideoIO/MultitrackMovieRecorder.swift
+++ b/Sources/VideoIO/MultitrackMovieRecorder.swift
@@ -69,9 +69,12 @@ public final class MultitrackMovieRecorder {
         
         public var numberOfAudioTracks: Int
         
-        public init(videoTrackCount: Int, audioTrackCount: Int) {
+        public var shouldOptimizeForNetworkUse: Bool
+        
+        public init(videoTrackCount: Int, audioTrackCount: Int, optimizeForNetworkUse: Bool = true) {
             numberOfVideoTracks = videoTrackCount
             numberOfAudioTracks = audioTrackCount
+            shouldOptimizeForNetworkUse = optimizeForNetworkUse
         }
     }
     
@@ -135,7 +138,7 @@ public final class MultitrackMovieRecorder {
         try? fileManager.removeItem(at: url)
         self.assetWriter = try AVAssetWriter(url: url, fileType: fileType)
         self.assetWriter.metadata = self.configuration.metadata
-        self.assetWriter.shouldOptimizeForNetworkUse = true
+        self.assetWriter.shouldOptimizeForNetworkUse = configuration.shouldOptimizeForNetworkUse
     }
     
     private func checkError() throws {
@@ -519,8 +522,12 @@ public final class MovieRecorder {
         /// Set to `true` to record both video and audio.
         public var hasAudio: Bool
         
-        public init(hasAudio: Bool) {
+        /// Set to `true` to write the file in a way that is more suitable for playback over a network.
+        public var shouldOptimizeForNetworkUse: Bool
+        
+        public init(hasAudio: Bool, optimizeForNetworkUse: Bool = true) {
             self.hasAudio = hasAudio
+            self.shouldOptimizeForNetworkUse = optimizeForNetworkUse
         }
     }
     
@@ -528,7 +535,7 @@ public final class MovieRecorder {
     
     public init(url: URL, configuration: Configuration) throws {
         self.configuration = configuration
-        var internalConfiguration = MultitrackMovieRecorder.Configuration(videoTrackCount: 1, audioTrackCount: configuration.hasAudio ? 1 : 0)
+        var internalConfiguration = MultitrackMovieRecorder.Configuration(videoTrackCount: 1, audioTrackCount: configuration.hasAudio ? 1 : 0, optimizeForNetworkUse: configuration.shouldOptimizeForNetworkUse)
         internalConfiguration.metadata = configuration.metadata
         internalConfiguration.videoOrientation = configuration.videoOrientation
         internalConfiguration.videoSettings = configuration.videoSettings


### PR DESCRIPTION
Although these methods are safe to use use even with aligned audio, I thought it made sense to make this optional to reduce unnecessary work. The user would be aware if they were using different audio/video frameworks.