### PR TITLE
Support for macOS 14

### DIFF
--- a/Sources/VideoIO/Camera.swift
+++ b/Sources/VideoIO/Camera.swift
@@ -400,7 +400,16 @@ public class Camera {
     
     internal var photoCaptureDelegateHandlers: [AnyObject] = []
     
+    private var _audioQueueCaptureSession: AnyObject?
+    
     @available(macOS, unavailable)
-    internal var audioQueueCaptureSession: AudioQueueCaptureSession?
+    internal var audioQueueCaptureSession: AudioQueueCaptureSession? {
+        get {
+            _audioQueueCaptureSession as? AudioQueueCaptureSession
+        }
+        set {
+            _audioQueueCaptureSession = newValue
+        }
+    }
 }
 

--- a/Sources/VideoIO/Camera.swift
+++ b/Sources/VideoIO/Camera.swift
@@ -151,6 +151,17 @@ public class Camera {
         }
     }
     
+    public func removeVideoCaptureDevice() {
+        self.captureSession.beginConfiguration()
+
+        if let currentVideoDeviceInput = self.videoDeviceInput {
+            self.captureSession.removeInput(currentVideoDeviceInput)
+            self.videoDeviceInput = nil
+        }
+        
+        self.captureSession.commitConfiguration()
+    }
+    
     public var videoCaptureConnection: AVCaptureConnection? {
         return self.videoDataOutput?.connection(with: .video)
     }

--- a/Sources/VideoIO/Camera.swift
+++ b/Sources/VideoIO/Camera.swift
@@ -151,17 +151,6 @@ public class Camera {
         }
     }
     
-    public func removeVideoCaptureDevice() {
-        self.captureSession.beginConfiguration()
-
-        if let currentVideoDeviceInput = self.videoDeviceInput {
-            self.captureSession.removeInput(currentVideoDeviceInput)
-            self.videoDeviceInput = nil
-        }
-        
-        self.captureSession.commitConfiguration()
-    }
-    
     public var videoCaptureConnection: AVCaptureConnection? {
         return self.videoDataOutput?.connection(with: .video)
     }

--- a/Sources/VideoIO/PlayerVideoOutput.swift
+++ b/Sources/VideoIO/PlayerVideoOutput.swift
@@ -8,7 +8,7 @@
 import Foundation
 import AVFoundation
 
-@available(macOS, unavailable)
+@available(macOS 14.0, *)@available(macOS, unavailable)
 public class PlayerVideoOutput: NSObject {
     
     public struct Configuration {


### PR DESCRIPTION
This PR adds support for macOS 14.

macOS 14 adds support for CADisplayLink which means the current source will not compile.

This PR resolves the discussion in #45.