### PR TITLE
Add Support for Audio Switching

### DIFF
--- a/Sources/VideoIO/Camera.swift
+++ b/Sources/VideoIO/Camera.swift
@@ -151,6 +151,17 @@ public class Camera {
         }
     }
     
+    public func removeVideoCaptureDevice() {
+        self.captureSession.beginConfiguration()
+
+        if let currentVideoDeviceInput = self.videoDeviceInput {
+            self.captureSession.removeInput(currentVideoDeviceInput)
+            self.videoDeviceInput = nil
+        }
+        
+        self.captureSession.commitConfiguration()
+    }
+    
     public var videoCaptureConnection: AVCaptureConnection? {
         return self.videoDataOutput?.connection(with: .video)
     }

--- a/Sources/VideoIO/Camera.swift
+++ b/Sources/VideoIO/Camera.swift
@@ -151,17 +151,6 @@ public class Camera {
         }
     }
     
-    public func removeVideoCaptureDevice() {
-        self.captureSession.beginConfiguration()
-
-        if let currentVideoDeviceInput = self.videoDeviceInput {
-            self.captureSession.removeInput(currentVideoDeviceInput)
-            self.videoDeviceInput = nil
-        }
-        
-        self.captureSession.commitConfiguration()
-    }
-    
     public var videoCaptureConnection: AVCaptureConnection? {
         return self.videoDataOutput?.connection(with: .video)
     }


### PR DESCRIPTION
This PR adds support for audio switching using the methods discussed in #38, #36 and #42

Changes:

- Renamed `defaultCameraDeviceTypes` to `defaultVideoDeviceTypes`
- Deprecated initializer
- Added new initializer: `init(captureSessionPreset:defaultCameraPosition:defaultVideoDeviceTypes: defaultAudioDeviceTypes:configurator:)`
- Add `removeVideoCaptureDevice`
- Modify `enableVideoDataOutput` to allow specific of device when nil to match `switchToVideoDevice`
- Add `switchToAudioCaptureDevice`, `removeAudioCaptureDevice` to match video methods
- Rework `enableAudioCaptureDevice` to match video

